### PR TITLE
CSize -> Word32

### DIFF
--- a/languages/haskell/flipper/src/Flipper/Internal/FS.hs
+++ b/languages/haskell/flipper/src/Flipper/Internal/FS.hs
@@ -33,4 +33,4 @@ checksum (Buffer fp o l) = unsafeDupablePerformIO $
     withForeignPtr fp (\p -> return (c_fs_checksum (plusPtr p o) (fromIntegral l)))
 
 foreign import ccall safe "flipper/fs/crc.h checksum"
-    c_fs_checksum :: Ptr Word8 -> CSize -> Word16
+    c_fs_checksum :: Ptr Word8 -> Word32 -> Word16

--- a/languages/haskell/flipper/src/Flipper/Internal/NVM.hs
+++ b/languages/haskell/flipper/src/Flipper/Internal/NVM.hs
@@ -118,4 +118,4 @@ foreign import ccall safe "flipper/nvm.h nvm_pull"
     c_nvm_pull :: Ptr Word8 -> Word32 -> Word32 -> IO ()
 
 foreign import ccall safe "flipper/nvm.h nvm_dereference"
-    c_nvm_dereference :: Word32 -> CSize -> IO (Ptr Word8)
+    c_nvm_dereference :: Word32 -> Word32 -> IO (Ptr Word8)

--- a/languages/haskell/flipper/src/Flipper/Internal/SPI.hs
+++ b/languages/haskell/flipper/src/Flipper/Internal/SPI.hs
@@ -69,7 +69,7 @@ foreign import ccall safe "flipper/spi.h spi_get"
     c_spi_get :: IO Word8
 
 foreign import ccall safe "flipper/spi.h spi_push"
-    c_spi_push :: Ptr Word8 -> CSize -> IO ()
+    c_spi_push :: Ptr Word8 -> Word32 -> IO ()
 
 foreign import ccall safe "flipper/spi.h spi_pull"
-    c_spi_pull :: Ptr Word8 -> CSize -> IO ()
+    c_spi_pull :: Ptr Word8 -> Word32 -> IO ()

--- a/languages/haskell/flipper/src/Flipper/Internal/USART.hs
+++ b/languages/haskell/flipper/src/Flipper/Internal/USART.hs
@@ -133,10 +133,10 @@ foreign import ccall safe "flipper/usart.h usart0_get"
     c_usart0_get :: IO Word8
 
 foreign import ccall safe "flipper/usart.h usart0_push"
-    c_usart0_push :: Ptr Word8 -> CSize -> IO ()
+    c_usart0_push :: Ptr Word8 -> Word32 -> IO ()
 
 foreign import ccall safe "flipper/usart.h usart0_pull"
-    c_usart0_pull :: Ptr Word8 -> CSize -> IO ()
+    c_usart0_pull :: Ptr Word8 -> Word32 -> IO ()
 
 foreign import ccall safe "flipper/usart.h usart1_enable"
     c_usart1_enable :: IO ()
@@ -154,10 +154,10 @@ foreign import ccall safe "flipper/usart.h usart1_get"
     c_usart1_get :: IO Word8
 
 foreign import ccall safe "flipper/usart.h usart1_push"
-    c_usart1_push :: Ptr Word8 -> CSize -> IO ()
+    c_usart1_push :: Ptr Word8 -> Word32 -> IO ()
 
 foreign import ccall safe "flipper/usart.h usart1_pull"
-    c_usart1_pull :: Ptr Word8 -> CSize -> IO ()
+    c_usart1_pull :: Ptr Word8 -> Word32 -> IO ()
 
 foreign import ccall safe "flipper/usart.h dbgu_enable"
     c_dbgu_enable :: IO ()
@@ -175,7 +175,7 @@ foreign import ccall safe "flipper/usart.h dbgu_get"
     c_dbgu_get :: IO Word8
 
 foreign import ccall safe "flipper/usart.h dbgu_push"
-    c_dbgu_push :: Ptr Word8 -> CSize -> IO ()
+    c_dbgu_push :: Ptr Word8 -> Word32 -> IO ()
 
 foreign import ccall safe "flipper/usart.h dbgu_pull"
-    c_dbgu_pull :: Ptr Word8 -> CSize -> IO ()
+    c_dbgu_pull :: Ptr Word8 -> Word32 -> IO ()

--- a/languages/haskell/flipper/src/Flipper/Internal/USB.hs
+++ b/languages/haskell/flipper/src/Flipper/Internal/USB.hs
@@ -69,7 +69,7 @@ foreign import ccall safe "flipper/usb.h usb_get"
     c_usb_get :: IO Word8
 
 foreign import ccall safe "flipper/usb.h usb_push"
-    c_usb_push :: Ptr Word8 -> CSize -> IO ()
+    c_usb_push :: Ptr Word8 -> Word32 -> IO ()
 
 foreign import ccall safe "flipper/usb.h usb_pull"
-    c_usb_pull :: Ptr Word8 -> CSize -> IO ()
+    c_usb_pull :: Ptr Word8 -> Word32 -> IO ()


### PR DESCRIPTION
Change `CSize` to `Word32` to reflect the changes to how sizes are handled.
