### PR TITLE
Implemented Java class/C struct translation and refactored drivers.

### DIFF
--- a/languages/java/src/io/flipper/java/drivers/Button.java
+++ b/languages/java/src/io/flipper/java/drivers/Button.java
@@ -1,3 +1,5 @@
+package io.flipper.java.drivers;
+
 /**
  * Wrapper class for Flipper's on-board button.
  */

--- a/languages/java/src/io/flipper/java/drivers/Config.java
+++ b/languages/java/src/io/flipper/java/drivers/Config.java
@@ -1,3 +1,5 @@
+package io.flipper.java.drivers;
+
 /**
  * Created by Nick Mosher on 5/31/16.
  */

--- a/languages/java/src/io/flipper/java/drivers/Error.java
+++ b/languages/java/src/io/flipper/java/drivers/Error.java
@@ -1,7 +1,11 @@
+package io.flipper.java.drivers;
+
+import io.flipper.java.util.FlipperException;
+
 /**
- * Created by nick on 5/14/16.
+ * Created by Nick Mosher on 5/14/16.
  */
-class Error {
+public class Error {
 
     private Flipper mFlipper;
 

--- a/languages/java/src/io/flipper/java/drivers/Flipper.java
+++ b/languages/java/src/io/flipper/java/drivers/Flipper.java
@@ -1,6 +1,11 @@
+package io.flipper.java.drivers;
+
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
+import io.flipper.java.util.Structure;
+
+import java.lang.*;
 
 /**
  * Created by Nick Mosher on 4/1/16.

--- a/languages/java/src/io/flipper/java/drivers/Fs.java
+++ b/languages/java/src/io/flipper/java/drivers/Fs.java
@@ -1,4 +1,7 @@
+package io.flipper.java.drivers;
+
 import java.io.File;
+import java.lang.*;
 
 /**
  * Created by Nick Mosher on 5/31/16.

--- a/languages/java/src/io/flipper/java/drivers/I2c.java
+++ b/languages/java/src/io/flipper/java/drivers/I2c.java
@@ -1,5 +1,10 @@
+package io.flipper.java.drivers;
+
 import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
+import io.flipper.java.util.Structure;
+
+import java.lang.*;
 
 /**
  * Created by Nick Mosher on 5/31/16.

--- a/languages/java/src/io/flipper/java/drivers/Io.java
+++ b/languages/java/src/io/flipper/java/drivers/Io.java
@@ -1,7 +1,9 @@
+package io.flipper.java.drivers;
+
 /**
  * Created by Nick Mosher on 4/1/16.
  */
-class Io {
+public class Io {
 
     private Flipper mFlipper;
 

--- a/languages/java/src/io/flipper/java/drivers/Led.java
+++ b/languages/java/src/io/flipper/java/drivers/Led.java
@@ -1,3 +1,5 @@
+package io.flipper.java.drivers;
+
 /**
  * Wrapper class for Flipper's on-board RGB LED.
  */

--- a/languages/java/src/io/flipper/java/drivers/Spi.java
+++ b/languages/java/src/io/flipper/java/drivers/Spi.java
@@ -1,5 +1,10 @@
+package io.flipper.java.drivers;
+
 import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
+import io.flipper.java.util.Structure;
+
+import java.lang.*;
 
 /**
  * Created by Nick Mosher on 6/2/16.

--- a/languages/java/src/io/flipper/java/drivers/Usart.java
+++ b/languages/java/src/io/flipper/java/drivers/Usart.java
@@ -1,5 +1,10 @@
+package io.flipper.java.drivers;
+
 import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
+import io.flipper.java.util.Structure;
+
+import java.lang.*;
 
 /**
  * Created by Nick Mosher on 5/31/16.

--- a/languages/java/src/io/flipper/java/drivers/Usb.java
+++ b/languages/java/src/io/flipper/java/drivers/Usb.java
@@ -1,5 +1,10 @@
+package io.flipper.java.drivers;
+
 import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
+import io.flipper.java.util.Structure;
+
+import java.lang.*;
 
 /**
  * Created by Nick Mosher on 6/2/16.

--- a/languages/java/src/io/flipper/java/util/FlipperException.java
+++ b/languages/java/src/io/flipper/java/util/FlipperException.java
@@ -1,3 +1,5 @@
+package io.flipper.java.util;
+
 /**
  * Created by Nick Mosher on 5/14/16.
  */

--- a/languages/java/src/io/flipper/java/util/Structure.java
+++ b/languages/java/src/io/flipper/java/util/Structure.java
@@ -1,3 +1,5 @@
+package io.flipper.java.util;
+
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
@@ -50,11 +52,10 @@ public class Structure extends com.sun.jna.Structure {
 
     /**
      * Helper method provided by JNA's Structure class allows for measurement
-     * of the byte-size of this Structure. Default-access allows Flipper
-     * drivers to utilize this capability.
+     * of the byte-size of this Structure.
      * @return The size (in bytes) of this Structure.
      */
-    int calculateSize() {
+    public int calculateSize() {
         return super.calculateSize(false);
     }
 }


### PR DESCRIPTION
JNA has very well-built facilities for creating "Structure" classes which can then be passed into/out of bindings that equate to any type of reference parameter. However, there are several overhead requirements to JNA's process that make the translation cumbersome and non-trivial. I've created a subclass of JNA's Structure class (also called "Structure", but in the io.flipper.java package) which helps to alleviate several of these difficulties.

Here's a brief illustration of using a vanilla JNA Structure versus using my extended Flipper Structure:

``` Java
public class MyStruct extends com.sun.jna.Structure {
    int a;
    int b;
    protected List getFieldOrder() {
        return Arrays.asList(new String[]{"a", "b"});
    }
}
```

Versus:

``` Java
public class MyStruct extends io.flipper.java.Structure {
    int a;
    int b;
}
```

By creating a custom Structure class, we 1) have fine-grained control over the exposure of Structure methods, 2) can override Structure methods for custom functionality, and 3) include Structure inside of the io.flipper.java package where it's easily visible and accessible to users.

To use a Structure in a driver, simply pass it in as a parameter to an overloaded function that accepts it:

``` Java
MyStruct struct = new MyStruct();
flipper.usb.pull(struct);
System.out.println("Got a=" + struct.a + " from usb!");
```

Note that the Java representation of a Structure must be aligned correctly in terms of the packing for the native system, and misalignment will obviously cause misinterpretation of data.
