### PR TITLE
Implement LED bindings with new rust FMR machinery

### DIFF
--- a/console/src/bin/modules_cli.rs
+++ b/console/src/bin/modules_cli.rs
@@ -18,6 +18,7 @@
 
 use flipper;
 use console::CliError;
+use flipper::StandardModule;
 use clap::{App, AppSettings, Arg, ArgMatches};
 use failure::Error;
 
@@ -115,8 +116,9 @@ pub mod led {
         let green = args.value_of("green").unwrap().parse::<u8>().unwrap();
         let blue = args.value_of("blue").unwrap().parse::<u8>().unwrap();
 
-        let _ = flipper::Flipper::attach();
-        flipper::fsm::led::rgb(red, green, blue);
+        let flipper = flipper::Flipper::attach();
+        let led = flipper::fsm::led::Led::bind(&flipper);
+        led.rgb(red, green, blue);
         Ok(())
     }
 }

--- a/languages/rust/examples/led.rs
+++ b/languages/rust/examples/led.rs
@@ -1,0 +1,10 @@
+extern crate flipper;
+
+use flipper::{Flipper, StandardModule};
+use flipper::fsm::led::Led;
+
+fn main() {
+    Flipper::attach();
+    let led = Led::new();
+    led.rgb(10, 0, 0);
+}

--- a/languages/rust/src/fsm/led.rs
+++ b/languages/rust/src/fsm/led.rs
@@ -1,17 +1,55 @@
+use ::{
+    Flipper,
+    StandardModule,
+    StandardModuleFFI,
+    ModuleFFI,
+    _lf_module,
+};
+
+use fmr::{
+    Args,
+    lf_invoke,
+};
+
 #[link(name = "flipper")]
 extern {
-    fn led_configure() -> u32;
-    fn led_rgb(r: u8, g: u8, b: u8);
+    static _led: _lf_module;
 }
 
-pub fn configure() -> u32 {
-    unsafe {
-        led_configure()
+pub struct Led {
+    module: ModuleFFI,
+}
+
+impl StandardModule for Led {
+    fn new() -> Self {
+        unsafe {
+            let module = StandardModuleFFI { module_meta: &_led };
+            Led {
+                module: ModuleFFI::Standard(module),
+            }
+        }
+    }
+
+    fn bind(flipper: &Flipper) -> Self {
+        unsafe {
+            let module = StandardModuleFFI { module_meta: &_led };
+            Led {
+                module: ModuleFFI::Standard(module),
+            }
+        }
     }
 }
 
-pub fn rgb(r: u8, g: u8, b: u8) {
-    unsafe {
-        led_rgb(r, g, b)
+impl Led {
+    pub fn configure(&self) {
+        lf_invoke(&self.module, 0, Args::new())
+    }
+
+    pub fn rgb(&self, r: u8, g: u8, b: u8) {
+        let args = Args::new()
+            .append(r)
+            .append(g)
+            .append(b);
+        lf_invoke(&self.module, 1, args)
     }
 }

--- a/languages/rust/src/fsm/led.rs
+++ b/languages/rust/src/fsm/led.rs
@@ -1,3 +1,5 @@
+#![allow(non_upper_case_globals)]
+
 use ::{
     Flipper,
     StandardModule,
@@ -30,7 +32,7 @@ impl StandardModule for Led {
         }
     }
 
-    fn bind(flipper: &Flipper) -> Self {
+    fn bind(_: &Flipper) -> Self {
         unsafe {
             let module = StandardModuleFFI { module_meta: &_led };
             Led {


### PR DESCRIPTION
I realized I had this sitting on my computer for some time now and that there's no reason not to push it. This just adds the new led implementation and a command line interface for it as `flipper module led <red> <green> <blue>`