### PR TITLE
Rename '_fmr_header.class' to 'type'

### DIFF
--- a/carbon/atsam4s/system.c
+++ b/carbon/atsam4s/system.c
@@ -29,10 +29,10 @@ lf_return_t fmr_push(struct _fmr_push_pull_packet *packet) {
 		return lf_error;
 	}
 	uart0_pull_wait(push_buffer, packet->length);
-	if (packet->header.class == fmr_send_class) {
+	if (packet->header.type == fmr_send_class) {
 		/* If we are copying data, simply return a pointer to the copied data. */
 		_e = (uintptr_t)push_buffer;
-	} else if (packet->header.class == fmr_ram_load_class) {
+	} else if (packet->header.type == fmr_ram_load_class) {
 		_e = os_load_image(push_buffer);
 		return lf_success;
 	} else {
@@ -45,7 +45,7 @@ lf_return_t fmr_push(struct _fmr_push_pull_packet *packet) {
 
 lf_return_t fmr_pull(struct _fmr_push_pull_packet *packet) {
 	lf_return_t _e = lf_success;
-	if (packet->header.class == fmr_receive_class) {
+	if (packet->header.type == fmr_receive_class) {
 		/* If we are receiving data, simply push the memory. */
 		_e = uart0_push((void *)*(uint64_t *)(packet->call.parameters), packet->length);
 	} else {

--- a/library/src/libflipper.c
+++ b/library/src/libflipper.c
@@ -134,10 +134,10 @@ void lf_debug_packet(struct _fmr_packet *packet, size_t length) {
 		printf("\t└─ checksum:\t0x%x\n", packet->header.checksum);
 		printf("\t└─ length:\t\t%d bytes (%.02f%%)\n", packet->header.length, (float) packet->header.length/sizeof(struct _fmr_packet)*100);
 		char *classstrs[] = { "standard", "user", "push", "pull", "send", "receive", "load", "event" };
-		printf("\t└─ class\t\t%s\n", classstrs[packet->header.class]);
+		printf("\t└─ class\t\t%s\n", classstrs[packet->header.type]);
 		struct _fmr_invocation_packet *invocation = (struct _fmr_invocation_packet *)(packet);
 		struct _fmr_push_pull_packet *pushpull = (struct _fmr_push_pull_packet *)(packet);
-		switch (packet->header.class) {
+		switch (packet->header.type) {
 			case fmr_standard_invocation_class:
 				lf_debug_call(&invocation->call);
 			break;

--- a/runtime/include/flipper/fmr.h
+++ b/runtime/include/flipper/fmr.h
@@ -131,8 +131,8 @@ struct LF_PACKED _fmr_header {
 	lf_crc_t checksum;
 	/* The length of the packet expressed in bytes. */
 	uint16_t length;
-	/* The packet's class. */
-	fmr_class class;
+	/* The packet's type. */
+	fmr_class type;
 };
 
 /* Standardizes the notion of an argument. */

--- a/runtime/src/fmr.c
+++ b/runtime/src/fmr.c
@@ -107,7 +107,7 @@ int fmr_perform(struct _fmr_packet *packet, struct _fmr_result *result) {
 	struct _fmr_invocation *call = &((struct _fmr_invocation_packet *)packet)->call;
 
 	/* Switch through the packet subclasses and invoke the appropriate handler for each. */
-	switch (packet->header.class) {
+	switch (packet->header.type) {
 		case fmr_standard_invocation_class:
 			result->value = fmr_execute(call->index, call->function, call->ret, call->argc, call->types, call->parameters);
 		break;

--- a/runtime/src/runtime.c
+++ b/runtime/src/runtime.c
@@ -51,10 +51,10 @@ lf_return_t lf_invoke(struct _lf_module *module, lf_function function, lf_type r
 	#warning Remove this.
 	/* If the user module bit is set, make the invocation a user invocation. */
 	if (module->index & FMR_USER_INVOCATION_BIT) {
-		_packet.header.class = fmr_user_invocation_class;
+		_packet.header.type = fmr_user_invocation_class;
 	} else {
 		/* Otherwise, make it a standard invocation. */
-		_packet.header.class = fmr_standard_invocation_class;
+		_packet.header.type = fmr_standard_invocation_class;
 	}
 
 	/* Generate the function call in the outgoing packet. */
@@ -84,7 +84,7 @@ lf_return_t lf_push(struct _lf_module *module, lf_function function, void *sourc
 	memset(&_packet, 0, sizeof(struct _fmr_packet));
 	_packet.header.magic = FMR_MAGIC_NUMBER;
 	_packet.header.length = sizeof(struct _fmr_push_pull_packet);
-	_packet.header.class = fmr_push_class;
+	_packet.header.type = fmr_push_class;
 	struct _fmr_push_pull_packet *packet = (struct _fmr_push_pull_packet *)(&_packet);
 	packet->length = length;
 
@@ -118,7 +118,7 @@ lf_return_t lf_pull(struct _lf_module *module, lf_function function, void *desti
 	memset(&_packet, 0, sizeof(struct _fmr_packet));
 	_packet.header.magic = FMR_MAGIC_NUMBER;
 	_packet.header.length = sizeof(struct _fmr_push_pull_packet);
-	_packet.header.class = fmr_pull_class;
+	_packet.header.type = fmr_pull_class;
 	struct _fmr_push_pull_packet *packet = (struct _fmr_push_pull_packet *)(&_packet);
 	packet->length = length;
 
@@ -152,7 +152,7 @@ int lf_load(void *source, lf_size_t length, struct _lf_device *device) {
 	memset(&_packet, 0, sizeof(struct _fmr_packet));
 	_packet.header.magic = FMR_MAGIC_NUMBER;
 	_packet.header.length = sizeof(struct _fmr_push_pull_packet);
-	_packet.header.class = fmr_ram_load_class;
+	_packet.header.type = fmr_ram_load_class;
 	struct _fmr_push_pull_packet *packet = (struct _fmr_push_pull_packet *)(&_packet);
 	packet->length = length;
 	_packet.header.checksum = lf_crc(packet, _packet.header.length);


### PR DESCRIPTION
If any of the Flipper headers are included in a C++ context, this name
breaks compilation. Rename it to avoid the conflict.