### PR TITLE
Flipper attach checks for NULL on failed attach

### DIFF
--- a/console/Cargo.lock
+++ b/console/Cargo.lock
@@ -180,6 +180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "flipper"
 version = "0.1.0"
 dependencies = [
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/console/src/bin/main.rs
+++ b/console/src/bin/main.rs
@@ -50,6 +50,8 @@ use clap::{
     ArgMatches,
 };
 
+type Result<T> = std::result::Result<T, Error>;
+
 const ABOUT: &'static str = "flipper: Manage and control Flipper from the command line";
 
 fn main() {
@@ -87,7 +89,7 @@ pub fn app() -> App<'static, 'static> {
 /// are implemented by a child module rather than by the `flipper` module
 /// itself. Because of this, we have to explicitly pass the name of the matched
 /// command to the child module (e.g. the "c" in `(c @ "boot")`).
-pub fn execute(args: &ArgMatches) -> Result<(), Error> {
+pub fn execute(args: &ArgMatches) -> Result<()> {
     match args.subcommand() {
         ("module", Some(m)) => modules_cli::execute(m),
         ("generate", Some(m)) => bindings_cli::execute(m),

--- a/console/src/bin/modules_cli.rs
+++ b/console/src/bin/modules_cli.rs
@@ -16,7 +16,11 @@
 //! $
 //! ```
 
-use flipper;
+use Result;
+use flipper::{
+    Flipper,
+    fsm::led::Led,
+};
 use console::CliError;
 #[allow(unused_imports)]
 use flipper::StandardModule;
@@ -50,7 +54,7 @@ pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
         ])
 }
 
-pub fn execute(args: &ArgMatches) -> Result<(), Error> {
+pub fn execute(args: &ArgMatches) -> Result<()> {
     if args.is_present("repl") {
         repl();
         ::std::process::exit(0);
@@ -112,13 +116,13 @@ pub mod led {
             )
     }
 
-    pub fn execute(args: &ArgMatches) -> Result<(), Error> {
+    pub fn execute(args: &ArgMatches) -> Result<()> {
         let red = args.value_of("red").unwrap().parse::<u8>().unwrap();
         let green = args.value_of("green").unwrap().parse::<u8>().unwrap();
         let blue = args.value_of("blue").unwrap().parse::<u8>().unwrap();
 
-        let flipper = flipper::Flipper::attach();
-        let led = flipper::fsm::led::Led::bind(&flipper);
+        let flipper = Flipper::attach().map_err(Error::from)?;
+        let led = Led::bind(&flipper);
         led.rgb(red, green, blue);
         Ok(())
     }

--- a/console/src/hardware/fdfu.rs
+++ b/console/src/hardware/fdfu.rs
@@ -371,7 +371,13 @@ pub fn flash(firmware: Arc<[u8]>, verify: bool) -> mpsc::Receiver<Progress> {
     let (mut sender, receiver) = mpsc::channel();
 
     thread::spawn(move || {
-        let flipper = Flipper::attach();
+        let flipper = match Flipper::attach() {
+            Ok(flipper) => flipper,
+            Err(e) => {
+                let _ = sender.send(Progress::Failed(e.into()));
+                return;
+            }
+        };
         flipper.select_u2_gpio();
 
         let mut bus = Uart0::new();

--- a/languages/rust/Cargo.toml
+++ b/languages/rust/Cargo.toml
@@ -11,3 +11,4 @@ path = "src/lib.rs"
 [dependencies]
 libc = "0.2.0"
 log = "0.4.1"
+failure = "0.1.1"

--- a/languages/rust/examples/led.rs
+++ b/languages/rust/examples/led.rs
@@ -4,7 +4,7 @@ use flipper::{Flipper, StandardModule};
 use flipper::fsm::led::Led;
 
 fn main() {
-    Flipper::attach();
+    let _flipper = Flipper::attach().expect("should attach to Flipper");
     let led = Led::new();
     led.rgb(10, 0, 0);
 }

--- a/languages/rust/examples/module_binding.rs
+++ b/languages/rust/examples/module_binding.rs
@@ -35,7 +35,7 @@ impl GpioToggle {
 }
 
 fn main() {
-    let flipper = Flipper::attach();
+    let flipper = Flipper::attach().expect("should attach to Flipper");
     let gpio: GpioToggle = GpioToggle::bind(&flipper);
     gpio.toggle();
 }

--- a/languages/rust/examples/uart0_binding.rs
+++ b/languages/rust/examples/uart0_binding.rs
@@ -5,8 +5,8 @@ use flipper::{Flipper, StandardModule};
 use flipper::fsm::uart0::{Uart0, UartBaud};
 
 fn main() {
-    let flipper = Flipper::attach_hostname("localhost");
+    let flipper = Flipper::attach_hostname("localhost").expect("should attach to fvm");
     let mut uart = Uart0::bind(&flipper);
-    uart.configure(&UartBaud::DFU, true);
+    uart.configure(UartBaud::DFU, true);
     let _ = uart.write(b"deadbeef deadbeef");
 }


### PR DESCRIPTION
Previously, the `Flipper::attach()` family of methods returned an irrefutable `Flipper`, but libflipper may fail to actually attach to a Flipper device. Now these methods return a `Result<Flipper, FlipperError>`, where `FlipperError` implements `failure::Fail`.

This also fixes the command-line `flipper flash` command, preventing it from segfaulting when attempting to flash when no flipper is attached.