### PR TITLE
Remove unneeded syscalls, pass CPU flag to linker for Thumb2 code link.

### DIFF
--- a/kernel/arch/armv7/syscalls.c
+++ b/kernel/arch/armv7/syscalls.c
@@ -21,8 +21,13 @@ extern caddr_t _sbrk(int increment) {
 	return (caddr_t)(previous);
 }
 
-extern int link(char *old, char *new) {
-	return -1 ;
+extern void uart0_put(char c);
+
+extern int _write(int file, char *ptr, int len) {
+	for (int i = 0; i < len; i ++, ptr ++) {
+		uart0_put(*ptr);
+	}
+	return 0;
 }
 
 extern int _close(int file) {
@@ -43,29 +48,4 @@ extern int _lseek(int file, int ptr, int dir) {
 
 extern int _read(int file, char *ptr, int len) {
 	return 0 ;
-}
-
-extern void uart0_put(char c);
-
-extern int _write(int file, char *ptr, int len) {
-	for (int i = 0; i < len; i ++, ptr ++) {
-		uart0_put(*ptr);
-	}
-	return 0;
-}
-
-extern void _exit(int status) {
-	while (1);
-}
-
-extern void _kill(int pid, int sig) {
-	return;
-}
-
-extern int _getpid(void) {
-	return -1;
-}
-
-extern void end(void) {
-	return;
 }

--- a/makefile
+++ b/makefile
@@ -54,9 +54,7 @@ ARM_CFLAGS   := -std=c99              \
                 -Wno-unused-parameter \
                 -Wno-expansion-to-defined \
                 -Os                   \
-                -mthumb               \
-                -march=armv7e-m       \
-                -mtune=cortex-m4      \
+                -mcpu=cortex-m4       \
                 -mfloat-abi=soft      \
                 -D__no_err_str__      \
                 -DATSAM4S             \
@@ -64,6 +62,7 @@ ARM_CFLAGS   := -std=c99              \
                 $(foreach inc,$(ARM_INC_DIRS),-I$(inc))
 
 ARM_LDFLAGS  := -nostartfiles                    \
+                -mcpu=cortex-m4                  \
                 -Wl,-T carbon/atsam4s/sam4s16.ld \
                 -Wl,--gc-sections
 

--- a/makefile
+++ b/makefile
@@ -55,6 +55,9 @@ ARM_CFLAGS   := -std=c99              \
                 -Wno-expansion-to-defined \
                 -Os                   \
                 -mcpu=cortex-m4       \
+				-mthumb               \
+                -march=armv7e-m       \
+                -mtune=cortex-m4      \
                 -mfloat-abi=soft      \
                 -D__no_err_str__      \
                 -DATSAM4S             \


### PR DESCRIPTION
Fixes problem with building `atsam4s` firmware image on brew/apt toolchains.