### PR TITLE
Fixing library link on Linux and Python 3 update

### DIFF
--- a/languages/python/flipper/__init__.py
+++ b/languages/python/flipper/__init__.py
@@ -1,5 +1,5 @@
-from lf import *
+from .lf import *
 
 # Enumerate the standard modules
-import led
-import gpio
+from . import led
+from . import gpio

--- a/languages/python/flipper/gpio.py
+++ b/languages/python/flipper/gpio.py
@@ -1,4 +1,4 @@
-import lf
+from . import lf
 
 # ! KEEP IN SYNC WITH THE FILES BELOW
 # carbon/include/flipper/carbon.h

--- a/languages/python/flipper/led.py
+++ b/languages/python/flipper/led.py
@@ -1,4 +1,4 @@
-import lf
+from . import lf
 
 # ! KEEP IN SYNC WITH THE FILES BELOW
 # carbon/include/flipper/led.h

--- a/makefile
+++ b/makefile
@@ -159,6 +159,7 @@ libflipper: $(X86_TARGET).so | $(BUILD)/include/flipper/.dir
 
 install-libflipper: libflipper
 	$(_v)cp $(BUILD)/$(X86_TARGET)/$(X86_TARGET).so $(PREFIX)/lib/
+	$(_v)ln -sf $(PREFIX)/lib/$(X86_TARGET).so /usr/lib/$(X86_TARGET).so
 	$(_v)cp -r $(BUILD)/include/* $(PREFIX)/include/
 	$(_v)cp assets/flipper.mk $(PREFIX)/include/
 	$(_v)mkdir -p $(PREFIX)/share/flipper
@@ -244,7 +245,7 @@ uninstall-utils:
 PY_DIR = $(shell python -m site --user-site)
 
 install-python:
-	$(_v)pip2 install languages/python --upgrade -q
+	$(_v)pip3 install languages/python --upgrade -q
 
 install:: install-python
 


### PR DESCRIPTION
On Linux the library needs to be placed in /usr/lib so we symlink /usr/local/lib/libflipper.so to /usr/lib/libflipper.so. Also, I updated the Python language files to work with Python 3.