### PR TITLE
Fixes issues found when compiling for fvm with gcc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 *.pyc
 .idea/
 cmake-build-debug/
+TAGS

--- a/assets/flipper.mk
+++ b/assets/flipper.mk
@@ -76,7 +76,13 @@ all:: $(HOST_TARGET)
 endif
 
 # Target when building for the Flipper Virtual Machine
-fvm: $(FVM_TARGET)
+fvm:: $(FVM_TARGET)
+
+ifeq ($(HOST_SRCS), )
+else
+fvm:: $(HOST_TARGET)
+endif
+
 
 echo[%]:
 	@echo 'Variable "$*" = "$($*)"'
@@ -110,8 +116,8 @@ $(HOST_BUILD)/%.c.o: %.c | $(HOST_BUILD_DIRS)
 $(HOST_GLUE_TARGET): $(HOST_GLUE_OBJS)
 	$(HOST_AR) -rcs $@ $^
 
-$(HOST_TARGET): $(HOST_BUILD)/$(MODULE).a $(HOST_OBJS)
-	$(HOST_LD) $(HOST_LDFLAGS) -lflipper -o $@ $^
+$(HOST_TARGET): $(HOST_OBJS) $(HOST_BUILD)/$(MODULE).a
+	$(HOST_LD) $(HOST_LDFLAGS) -o $@ $^ -lflipper
 
 # Keep track of #include dependencies for incremental builds
 -include $(HOST_DEPS)
@@ -124,7 +130,7 @@ $(FVM_BUILD)/package_data.c: | $(FVM_BUILD_DIRS)
 	echo "unsigned char package_bin[] = {\n};\nunsigned package_bin_len = 0;" > $@
 
 $(FVM_TARGET): $(FVM_OBJS)
-	$(FVM_LD) $(FVM_LDFLAGS) -shared -lflipper -o $@ $^
+	$(FVM_LD) $(FVM_LDFLAGS) -shared -o $@ $^ -lflipper
 
 # Keep track of #include dependencies for incremental builds
 -include $(FVM_DEPS)

--- a/library/include/flipper/posix/pio.h
+++ b/library/include/flipper/posix/pio.h
@@ -1,0 +1,296 @@
+/**
+ * \file
+ *
+ * Copyright (c) 2012-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _SAM4S16B_PIO_
+#define _SAM4S16B_PIO_
+
+#define PIO_PA0            (1u << 0)  /**< \brief Pin Controlled by PA0 */
+#define PIO_PA1            (1u << 1)  /**< \brief Pin Controlled by PA1 */
+#define PIO_PA2            (1u << 2)  /**< \brief Pin Controlled by PA2 */
+#define PIO_PA3            (1u << 3)  /**< \brief Pin Controlled by PA3 */
+#define PIO_PA4            (1u << 4)  /**< \brief Pin Controlled by PA4 */
+#define PIO_PA5            (1u << 5)  /**< \brief Pin Controlled by PA5 */
+#define PIO_PA6            (1u << 6)  /**< \brief Pin Controlled by PA6 */
+#define PIO_PA7            (1u << 7)  /**< \brief Pin Controlled by PA7 */
+#define PIO_PA8            (1u << 8)  /**< \brief Pin Controlled by PA8 */
+#define PIO_PA9            (1u << 9)  /**< \brief Pin Controlled by PA9 */
+#define PIO_PA10           (1u << 10) /**< \brief Pin Controlled by PA10 */
+#define PIO_PA11           (1u << 11) /**< \brief Pin Controlled by PA11 */
+#define PIO_PA12           (1u << 12) /**< \brief Pin Controlled by PA12 */
+#define PIO_PA13           (1u << 13) /**< \brief Pin Controlled by PA13 */
+#define PIO_PA14           (1u << 14) /**< \brief Pin Controlled by PA14 */
+#define PIO_PA15           (1u << 15) /**< \brief Pin Controlled by PA15 */
+#define PIO_PA16           (1u << 16) /**< \brief Pin Controlled by PA16 */
+#define PIO_PA17           (1u << 17) /**< \brief Pin Controlled by PA17 */
+#define PIO_PA18           (1u << 18) /**< \brief Pin Controlled by PA18 */
+#define PIO_PA19           (1u << 19) /**< \brief Pin Controlled by PA19 */
+#define PIO_PA20           (1u << 20) /**< \brief Pin Controlled by PA20 */
+#define PIO_PA21           (1u << 21) /**< \brief Pin Controlled by PA21 */
+#define PIO_PA22           (1u << 22) /**< \brief Pin Controlled by PA22 */
+#define PIO_PA23           (1u << 23) /**< \brief Pin Controlled by PA23 */
+#define PIO_PA24           (1u << 24) /**< \brief Pin Controlled by PA24 */
+#define PIO_PA25           (1u << 25) /**< \brief Pin Controlled by PA25 */
+#define PIO_PA26           (1u << 26) /**< \brief Pin Controlled by PA26 */
+#define PIO_PA27           (1u << 27) /**< \brief Pin Controlled by PA27 */
+#define PIO_PA28           (1u << 28) /**< \brief Pin Controlled by PA28 */
+#define PIO_PA29           (1u << 29) /**< \brief Pin Controlled by PA29 */
+#define PIO_PA30           (1u << 30) /**< \brief Pin Controlled by PA30 */
+#define PIO_PA31           (1u << 31) /**< \brief Pin Controlled by PA31 */
+#define PIO_PB0            (1u << 0)  /**< \brief Pin Controlled by PB0 */
+#define PIO_PB1            (1u << 1)  /**< \brief Pin Controlled by PB1 */
+#define PIO_PB2            (1u << 2)  /**< \brief Pin Controlled by PB2 */
+#define PIO_PB3            (1u << 3)  /**< \brief Pin Controlled by PB3 */
+#define PIO_PB4            (1u << 4)  /**< \brief Pin Controlled by PB4 */
+#define PIO_PB5            (1u << 5)  /**< \brief Pin Controlled by PB5 */
+#define PIO_PB6            (1u << 6)  /**< \brief Pin Controlled by PB6 */
+#define PIO_PB7            (1u << 7)  /**< \brief Pin Controlled by PB7 */
+#define PIO_PB8            (1u << 8)  /**< \brief Pin Controlled by PB8 */
+#define PIO_PB9            (1u << 9)  /**< \brief Pin Controlled by PB9 */
+#define PIO_PB10           (1u << 10) /**< \brief Pin Controlled by PB10 */
+#define PIO_PB11           (1u << 11) /**< \brief Pin Controlled by PB11 */
+#define PIO_PB12           (1u << 12) /**< \brief Pin Controlled by PB12 */
+#define PIO_PB13           (1u << 13) /**< \brief Pin Controlled by PB13 */
+#define PIO_PB14           (1u << 14) /**< \brief Pin Controlled by PB14 */
+/* ========== Pio definition for ADC peripheral ========== */
+#define PIO_PA17X1_AD0     (1u << 17) /**< \brief Adc signal: AD0 */
+#define PIO_PA18X1_AD1     (1u << 18) /**< \brief Adc signal: AD1 */
+#define PIO_PC13X1_AD10    (1u << 13) /**< \brief Adc signal: AD10 */
+#define PIO_PC15X1_AD11    (1u << 15) /**< \brief Adc signal: AD11 */
+#define PIO_PC12X1_AD12    (1u << 12) /**< \brief Adc signal: AD12 */
+#define PIO_PC29X1_AD13    (1u << 29) /**< \brief Adc signal: AD13 */
+#define PIO_PC30X1_AD14    (1u << 30) /**< \brief Adc signal: AD14 */
+#define PIO_PA19X1_AD2     (1u << 19) /**< \brief Adc signal: AD2/WKUP9 */
+#define PIO_PA19X1_WKUP9   (1u << 19) /**< \brief Adc signal: AD2/WKUP9 */
+#define PIO_PA20X1_AD3     (1u << 20) /**< \brief Adc signal: AD3/WKUP10 */
+#define PIO_PA20X1_WKUP10  (1u << 20) /**< \brief Adc signal: AD3/WKUP10 */
+#define PIO_PB0X1_AD4      (1u << 0)  /**< \brief Adc signal: AD4/RTCOUT0 */
+#define PIO_PB0X1_RTCOUT0  (1u << 0)  /**< \brief Adc signal: AD4/RTCOUT0 */
+#define PIO_PB1X1_AD5      (1u << 1)  /**< \brief Adc signal: AD5/RTCOUT1 */
+#define PIO_PB1X1_RTCOUT1  (1u << 1)  /**< \brief Adc signal: AD5/RTCOUT1 */
+#define PIO_PB2X1_AD6      (1u << 2)  /**< \brief Adc signal: AD6/WKUP12 */
+#define PIO_PB2X1_WKUP12   (1u << 2)  /**< \brief Adc signal: AD6/WKUP12 */
+#define PIO_PB3X1_AD7      (1u << 3)  /**< \brief Adc signal: AD7 */
+#define PIO_PA21X1_AD8     (1u << 21) /**< \brief Adc signal: AD8 */
+#define PIO_PA22X1_AD9     (1u << 22) /**< \brief Adc signal: AD9 */
+#define PIO_PA8B_ADTRG     (1u << 8)  /**< \brief Adc signal: ADTRG */
+/* ========== Pio definition for DACC peripheral ========== */
+#define PIO_PB13X1_DAC0    (1u << 13) /**< \brief Dacc signal: DAC0 */
+#define PIO_PB14X1_DAC1    (1u << 14) /**< \brief Dacc signal: DAC1 */
+#define PIO_PA2C_DATRG     (1u << 2)  /**< \brief Dacc signal: DATRG */
+/* ========== Pio definition for HSMCI peripheral ========== */
+#define PIO_PA28C_MCCDA    (1u << 28) /**< \brief Hsmci signal: MCCDA */
+#define PIO_PA29C_MCCK     (1u << 29) /**< \brief Hsmci signal: MCCK */
+#define PIO_PA30C_MCDA0    (1u << 30) /**< \brief Hsmci signal: MCDA0 */
+#define PIO_PA31C_MCDA1    (1u << 31) /**< \brief Hsmci signal: MCDA1 */
+#define PIO_PA26C_MCDA2    (1u << 26) /**< \brief Hsmci signal: MCDA2 */
+#define PIO_PA27C_MCDA3    (1u << 27) /**< \brief Hsmci signal: MCDA3 */
+/* ========== Pio definition for PIOA peripheral ========== */
+#define PIO_PA24D_PIODC0   (1u << 24) /**< \brief Pioa signal: PIODC0 */
+#define PIO_PA25D_PIODC1   (1u << 25) /**< \brief Pioa signal: PIODC1 */
+#define PIO_PA26D_PIODC2   (1u << 26) /**< \brief Pioa signal: PIODC2 */
+#define PIO_PA27D_PIODC3   (1u << 27) /**< \brief Pioa signal: PIODC3 */
+#define PIO_PA28D_PIODC4   (1u << 28) /**< \brief Pioa signal: PIODC4 */
+#define PIO_PA29D_PIODC5   (1u << 29) /**< \brief Pioa signal: PIODC5 */
+#define PIO_PA30D_PIODC6   (1u << 30) /**< \brief Pioa signal: PIODC6 */
+#define PIO_PA31D_PIODC7   (1u << 31) /**< \brief Pioa signal: PIODC7 */
+#define PIO_PA23D_PIODCCLK (1u << 23) /**< \brief Pioa signal: PIODCCLK */
+#define PIO_PA15D_PIODCEN1 (1u << 15) /**< \brief Pioa signal: PIODCEN1 */
+#define PIO_PA16D_PIODCEN2 (1u << 16) /**< \brief Pioa signal: PIODCEN2 */
+/* ========== Pio definition for PMC peripheral ========== */
+#define PIO_PA6B_PCK0      (1u << 6)  /**< \brief Pmc signal: PCK0 */
+#define PIO_PB13B_PCK0     (1u << 13) /**< \brief Pmc signal: PCK0 */
+#define PIO_PA17B_PCK1     (1u << 17) /**< \brief Pmc signal: PCK1 */
+#define PIO_PA21B_PCK1     (1u << 21) /**< \brief Pmc signal: PCK1 */
+#define PIO_PA18B_PCK2     (1u << 18) /**< \brief Pmc signal: PCK2 */
+#define PIO_PA31B_PCK2     (1u << 31) /**< \brief Pmc signal: PCK2 */
+#define PIO_PB3B_PCK2      (1u << 3)  /**< \brief Pmc signal: PCK2 */
+/* ========== Pio definition for PWM peripheral ========== */
+#define PIO_PA9C_PWMFI0    (1u << 9)  /**< \brief Pwm signal: PWMFI0 */
+#define PIO_PA10C_PWMFI1   (1u << 10) /**< \brief Pwm signal: PWMFI1 */
+#define PIO_PA18D_PWMFI2   (1u << 18) /**< \brief Pwm signal: PWMFI2 */
+#define PIO_PA0A_PWMH0     (1u << 0)  /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA11B_PWMH0    (1u << 11) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA23B_PWMH0    (1u << 23) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PB0A_PWMH0     (1u << 0)  /**< \brief Pwm signal: PWMH0 */
+#define PIO_PC18B_PWMH0    (1u << 18) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA1A_PWMH1     (1u << 1)  /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA12B_PWMH1    (1u << 12) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA24B_PWMH1    (1u << 24) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PB1A_PWMH1     (1u << 1)  /**< \brief Pwm signal: PWMH1 */
+#define PIO_PC19B_PWMH1    (1u << 19) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA2A_PWMH2     (1u << 2)  /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA13B_PWMH2    (1u << 13) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA25B_PWMH2    (1u << 25) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PB4B_PWMH2     (1u << 4)  /**< \brief Pwm signal: PWMH2 */
+#define PIO_PC20B_PWMH2    (1u << 20) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA7B_PWMH3     (1u << 7)  /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA14B_PWMH3    (1u << 14) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA17C_PWMH3    (1u << 17) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PB14B_PWMH3    (1u << 14) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PC21B_PWMH3    (1u << 21) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA19B_PWML0    (1u << 19) /**< \brief Pwm signal: PWML0 */
+#define PIO_PB5B_PWML0     (1u << 5)  /**< \brief Pwm signal: PWML0 */
+#define PIO_PC0B_PWML0     (1u << 0)  /**< \brief Pwm signal: PWML0 */
+#define PIO_PC13B_PWML0    (1u << 13) /**< \brief Pwm signal: PWML0 */
+#define PIO_PA20B_PWML1    (1u << 20) /**< \brief Pwm signal: PWML1 */
+#define PIO_PB12A_PWML1    (1u << 12) /**< \brief Pwm signal: PWML1 */
+#define PIO_PC1B_PWML1     (1u << 1)  /**< \brief Pwm signal: PWML1 */
+#define PIO_PC15B_PWML1    (1u << 15) /**< \brief Pwm signal: PWML1 */
+#define PIO_PA16C_PWML2    (1u << 16) /**< \brief Pwm signal: PWML2 */
+#define PIO_PA30A_PWML2    (1u << 30) /**< \brief Pwm signal: PWML2 */
+#define PIO_PB13A_PWML2    (1u << 13) /**< \brief Pwm signal: PWML2 */
+#define PIO_PC2B_PWML2     (1u << 2)  /**< \brief Pwm signal: PWML2 */
+#define PIO_PA15C_PWML3    (1u << 15) /**< \brief Pwm signal: PWML3 */
+#define PIO_PC3B_PWML3     (1u << 3)  /**< \brief Pwm signal: PWML3 */
+#define PIO_PC22B_PWML3    (1u << 22) /**< \brief Pwm signal: PWML3 */
+/* ========== Pio definition for SPI peripheral ========== */
+#define PIO_PA12A_MISO     (1u << 12) /**< \brief Spi signal: MISO */
+#define PIO_PA13A_MOSI     (1u << 13) /**< \brief Spi signal: MOSI */
+#define PIO_PA11A_NPCS0    (1u << 11) /**< \brief Spi signal: NPCS0 */
+#define PIO_PA9B_NPCS1     (1u << 9)  /**< \brief Spi signal: NPCS1 */
+#define PIO_PA31A_NPCS1    (1u << 31) /**< \brief Spi signal: NPCS1 */
+#define PIO_PB14A_NPCS1    (1u << 14) /**< \brief Spi signal: NPCS1 */
+#define PIO_PC4B_NPCS1     (1u << 4)  /**< \brief Spi signal: NPCS1 */
+#define PIO_PA10B_NPCS2    (1u << 10) /**< \brief Spi signal: NPCS2 */
+#define PIO_PA30B_NPCS2    (1u << 30) /**< \brief Spi signal: NPCS2 */
+#define PIO_PB2B_NPCS2     (1u << 2)  /**< \brief Spi signal: NPCS2 */
+#define PIO_PA3B_NPCS3     (1u << 3)  /**< \brief Spi signal: NPCS3 */
+#define PIO_PA5B_NPCS3     (1u << 5)  /**< \brief Spi signal: NPCS3 */
+#define PIO_PA22B_NPCS3    (1u << 22) /**< \brief Spi signal: NPCS3 */
+#define PIO_PA14A_SPCK     (1u << 14) /**< \brief Spi signal: SPCK */
+/* ========== Pio definition for SSC peripheral ========== */
+#define PIO_PA18A_RD       (1u << 18) /**< \brief Ssc signal: RD */
+#define PIO_PA20A_RF       (1u << 20) /**< \brief Ssc signal: RF */
+#define PIO_PA19A_RK       (1u << 19) /**< \brief Ssc signal: RK */
+#define PIO_PA17A_TD       (1u << 17) /**< \brief Ssc signal: TD */
+#define PIO_PA15A_TF       (1u << 15) /**< \brief Ssc signal: TF */
+#define PIO_PA16A_TK       (1u << 16) /**< \brief Ssc signal: TK */
+/* ========== Pio definition for TC0 peripheral ========== */
+#define PIO_PA4B_TCLK0     (1u << 4)  /**< \brief Tc0 signal: TCLK0 */
+#define PIO_PA28B_TCLK1    (1u << 28) /**< \brief Tc0 signal: TCLK1 */
+#define PIO_PA29B_TCLK2    (1u << 29) /**< \brief Tc0 signal: TCLK2 */
+#define PIO_PA0B_TIOA0     (1u << 0)  /**< \brief Tc0 signal: TIOA0 */
+#define PIO_PA15B_TIOA1    (1u << 15) /**< \brief Tc0 signal: TIOA1 */
+#define PIO_PA26B_TIOA2    (1u << 26) /**< \brief Tc0 signal: TIOA2 */
+#define PIO_PA1B_TIOB0     (1u << 1)  /**< \brief Tc0 signal: TIOB0 */
+#define PIO_PA16B_TIOB1    (1u << 16) /**< \brief Tc0 signal: TIOB1 */
+#define PIO_PA27B_TIOB2    (1u << 27) /**< \brief Tc0 signal: TIOB2 */
+/* ========== Pio definition for TWI0 peripheral ========== */
+#define PIO_PA4A_TWCK0     (1u << 4)  /**< \brief Twi0 signal: TWCK0 */
+#define PIO_PA3A_TWD0      (1u << 3)  /**< \brief Twi0 signal: TWD0 */
+/* ========== Pio definition for TWI1 peripheral ========== */
+#define PIO_PB5A_TWCK1     (1u << 5)  /**< \brief Twi1 signal: TWCK1 */
+#define PIO_PB4A_TWD1      (1u << 4)  /**< \brief Twi1 signal: TWD1 */
+/* ========== Pio definition for UART0 peripheral ========== */
+#define PIO_PA9A_URXD0     (1u << 9)  /**< \brief Uart0 signal: URXD0 */
+#define PIO_PA10A_UTXD0    (1u << 10) /**< \brief Uart0 signal: UTXD0 */
+/* ========== Pio definition for UART1 peripheral ========== */
+#define PIO_PB2A_URXD1     (1u << 2)  /**< \brief Uart1 signal: URXD1 */
+#define PIO_PB3A_UTXD1     (1u << 3)  /**< \brief Uart1 signal: UTXD1 */
+/* ========== Pio definition for USART0 peripheral ========== */
+#define PIO_PA8A_CTS0      (1u << 8)  /**< \brief Usart0 signal: CTS0 */
+#define PIO_PA7A_RTS0      (1u << 7)  /**< \brief Usart0 signal: RTS0 */
+#define PIO_PA5A_RXD0      (1u << 5)  /**< \brief Usart0 signal: RXD0 */
+#define PIO_PA2B_SCK0      (1u << 2)  /**< \brief Usart0 signal: SCK0 */
+#define PIO_PA6A_TXD0      (1u << 6)  /**< \brief Usart0 signal: TXD0 */
+/* ========== Pio definition for USART1 peripheral ========== */
+#define PIO_PA25A_CTS1     (1u << 25) /**< \brief Usart1 signal: CTS1 */
+#define PIO_PA26A_DCD1     (1u << 26) /**< \brief Usart1 signal: DCD1 */
+#define PIO_PA28A_DSR1     (1u << 28) /**< \brief Usart1 signal: DSR1 */
+#define PIO_PA27A_DTR1     (1u << 27) /**< \brief Usart1 signal: DTR1 */
+#define PIO_PA29A_RI1      (1u << 29) /**< \brief Usart1 signal: RI1 */
+#define PIO_PA24A_RTS1     (1u << 24) /**< \brief Usart1 signal: RTS1 */
+#define PIO_PA21A_RXD1     (1u << 21) /**< \brief Usart1 signal: RXD1 */
+#define PIO_PA23A_SCK1     (1u << 23) /**< \brief Usart1 signal: SCK1 */
+#define PIO_PA22A_TXD1     (1u << 22) /**< \brief Usart1 signal: TXD1 */
+/* ========== Pio indexes ========== */
+#define PIO_PA0_IDX        0
+#define PIO_PA1_IDX        1
+#define PIO_PA2_IDX        2
+#define PIO_PA3_IDX        3
+#define PIO_PA4_IDX        4
+#define PIO_PA5_IDX        5
+#define PIO_PA6_IDX        6
+#define PIO_PA7_IDX        7
+#define PIO_PA8_IDX        8
+#define PIO_PA9_IDX        9
+#define PIO_PA10_IDX       10
+#define PIO_PA11_IDX       11
+#define PIO_PA12_IDX       12
+#define PIO_PA13_IDX       13
+#define PIO_PA14_IDX       14
+#define PIO_PA15_IDX       15
+#define PIO_PA16_IDX       16
+#define PIO_PA17_IDX       17
+#define PIO_PA18_IDX       18
+#define PIO_PA19_IDX       19
+#define PIO_PA20_IDX       20
+#define PIO_PA21_IDX       21
+#define PIO_PA22_IDX       22
+#define PIO_PA23_IDX       23
+#define PIO_PA24_IDX       24
+#define PIO_PA25_IDX       25
+#define PIO_PA26_IDX       26
+#define PIO_PA27_IDX       27
+#define PIO_PA28_IDX       28
+#define PIO_PA29_IDX       29
+#define PIO_PA30_IDX       30
+#define PIO_PA31_IDX       31
+#define PIO_PB0_IDX        32
+#define PIO_PB1_IDX        33
+#define PIO_PB2_IDX        34
+#define PIO_PB3_IDX        35
+#define PIO_PB4_IDX        36
+#define PIO_PB5_IDX        37
+#define PIO_PB6_IDX        38
+#define PIO_PB7_IDX        39
+#define PIO_PB8_IDX        40
+#define PIO_PB9_IDX        41
+#define PIO_PB10_IDX       42
+#define PIO_PB11_IDX       43
+#define PIO_PB12_IDX       44
+#define PIO_PB13_IDX       45
+#define PIO_PB14_IDX       46
+
+#endif /* _SAM4S16B_PIO_ */

--- a/library/include/flipper/posix/posix.h
+++ b/library/include/flipper/posix/posix.h
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <flipper/posix/network.h>
 #include <flipper/posix/usb.h>
+#include <flipper/posix/pio.h>
 
 /* Define the modules that this platform uses. */
 #define __use_adc__
@@ -30,8 +31,8 @@
 #define __use_wdt__
 
 /* Declare the LF_VAR and LF_FUNC types for this platform. */
-#define LF_VAR __attribute__((section("__DATA,.lf.vars")))
-#define LF_FUNC __attribute__((section("__TEXT,.lf.funcs")))
+#define LF_VAR __attribute__((section(".lf.vars")))
+#define LF_FUNC __attribute__((section(".lf.funcs")))
 
 #else
 #error "Error: Multiple platforms targeted."


### PR DESCRIPTION
Adds header to posix includes for missing pio macros.
Fixes parameter ordering issues in flipper.mk.
Fixes section naming issue due to clang vs gcc differences.