### PR TITLE
Fixes compatibility issues with dyld on Ubuntu 18.04.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ brew install rust libusb avr-gcc dfu-programmer arm-gcc-bin
 apt-get install build-essential libusb-1.0-0-dev
 apt-get install dfu-programmer avr-libc binutils-avr gcc-avr
 apt-get install libnewlib-arm-none-eabi binutils-arm-none-eabi gcc-arm-none-eabi
-apt-get install pkg-config python-pip python-pyelftools
+apt-get install pkg-config python3-pip python3-pyelftools
 ```
 
 #### dnf (Fedora 28)

--- a/assets/flipper.mk
+++ b/assets/flipper.mk
@@ -155,11 +155,11 @@ all:: $$($1_TARGET)
 
 # Linking rule
 $$($1_TARGET): $$($1_OBJS)
-	$(_v)$$($1_LD) $$($1_LDFLAGS) -o $$($1_BUILD)/$$@ $$^
+	$(_v)$$($1_LD) -o $$($1_BUILD)/$$@ $$^ $$($1_LDFLAGS) 
 
 # Linking rule
 $$($1_ELF): $$($1_OBJS)
-	$(_v)$$($1_LD) $$($1_LDFLAGS) -o $$($1_BUILD)/$$@ $$^
+	$(_v)$$($1_LD) -o $$($1_BUILD)/$$@ $$^ $$($1_LDFLAGS) 
 
 # Objcopy-ing rule
 $$($1_HEX): $$($1_ELF)

--- a/library/library.mk
+++ b/library/library.mk
@@ -7,8 +7,13 @@ LIBFLIPPER_TARGET := libflipper
 LIBFLIPPER_PREFIX :=
 LIBFLIPPER_INC_DIRS := $(LIB_INC_DIRS) api/c carbon/atmegau2/include carbon/atsam4s/include carbon/hal/include platforms
 LIBFLIPPER_SRC_DIRS := $(LIB_SRC_DIRS) api/c kernel/arch/x64 carbon/hal/src platforms/posix
+ifdef DEBUG
 LIBFLIPPER_CFLAGS := $(LIB_CFLAGS) -fsanitize=address -g -fPIC $(shell pkg-config --cflags libusb-1.0)
 LIBFLIPPER_LDFLAGS := $(LIB_LDFLAGS) -fsanitize=address $(shell pkg-config --libs libusb-1.0)
+else
+LIBFLIPPER_CFLAGS := $(LIB_CFLAGS) -g -fPIC $(shell pkg-config --cflags libusb-1.0)
+LIBFLIPPER_LDFLAGS := $(LIB_LDFLAGS) $(shell pkg-config --libs libusb-1.0)
+endif
 
 TARGETS += LIBFLIPPER
 


### PR DESCRIPTION
Moves LD_FLAGS to end of linking command.
Removes --force flag from install-atmega2 in makefile.
Adds missing dependencies to README.md.

After fixing the above, I was able to load and test the example module with a flipper carbon on Ubuntu 18.04.