### PR TITLE
Update python package to python3

### DIFF
--- a/languages/python/flipper/__init__.py
+++ b/languages/python/flipper/__init__.py
@@ -1,5 +1,5 @@
-from lf import *
+from .lf import *
 
 # Enumerate the standard modules
-import led
-import gpio
+from .led import *
+from .gpio import *

--- a/languages/python/flipper/gpio.py
+++ b/languages/python/flipper/gpio.py
@@ -1,4 +1,4 @@
-import lf
+import flipper.lf as lf
 
 # ! KEEP IN SYNC WITH THE FILES BELOW
 # carbon/include/flipper/carbon.h

--- a/languages/python/flipper/led.py
+++ b/languages/python/flipper/led.py
@@ -1,4 +1,4 @@
-import lf
+import flipper.lf as lf
 
 # ! KEEP IN SYNC WITH THE FILES BELOW
 # carbon/include/flipper/led.h

--- a/makefile
+++ b/makefile
@@ -248,10 +248,11 @@ uninstall-utils:
 
 # --- LANGUAGES --- #
 
-PY_DIR = $(shell python3 -m site --user-site)
+install-python2:
+	$(_v)pip2 install --user languages/python --upgrade
 
 install-python:
-	$(_v)pip3 install languages/python --upgrade
+	$(_v)pip3 install --user languages/python --upgrade
 
 install:: install-python
 

--- a/makefile
+++ b/makefile
@@ -142,7 +142,8 @@ X86_SRC_DIRS := carbon/hal              \
                 library/platforms/posix \
                 runtime/src
 
-X86_CFLAGS :=   -std=gnu99              \
+X86_CFLAGS   := -std=gnu99              \
+                -g                      \
                 -Wall                   \
                 -Wextra                 \
                 -Wno-unused-parameter   \
@@ -247,10 +248,10 @@ uninstall-utils:
 
 # --- LANGUAGES --- #
 
-PY_DIR = $(shell python -m site --user-site)
+PY_DIR = $(shell python3 -m site --user-site)
 
 install-python:
-	$(_v)pip2 install languages/python --upgrade -q
+	$(_v)pip3 install languages/python --upgrade
 
 install:: install-python
 

--- a/utils/fdwarf/fdwarf.py
+++ b/utils/fdwarf/fdwarf.py
@@ -27,6 +27,39 @@ def get_die_at_offset(cu, offset):
 	for d in cu.iter_DIEs():
 		if d.offset == offset:
 			return d
+	print("Fatal: Failed to find die at offset %s in CU '%s'" % (str(hex(offset)), cu.get_top_DIE().attributes["DW_AT_name"].value))
+
+def get_name(cu, die):
+	while "DW_AT_abstract_origin" in die.attributes:
+		die = get_die_at_offset(cu, die.attributes["DW_AT_abstract_origin"].value)
+	if "DW_AT_name" in die.attributes:
+		return die.attributes["DW_AT_name"].value.decode("utf-8")
+	print("Fatal: Encountered nameless subprogram at offset %s in CU %s" % (hex(die.offset), cu.get_top_DIE().attributes["DW_AT_name"].value))
+	print(die)
+
+def get_type(cu, die):
+	while "DW_AT_abstract_origin" in die.attributes:
+		die = get_die_at_offset(cu, die.attributes["DW_AT_abstract_origin"].value)
+	if "DW_AT_type" in die.attributes:
+		tdie = get_die_at_offset(cu, die.attributes["DW_AT_type"].value)
+		# while tdie.tag == "DW_TAG_typedef":
+		# 	tdie = get_die_at_offset(cu, tdie.attributes["DW_AT_type"].value)
+		if "DW_AT_name" in tdie.attributes:
+			return tdie.attributes["DW_AT_name"].value.decode("utf-8")
+		else:
+			return "void*"
+	return "void"
+
+def get_size(cu, die):
+	while "DW_AT_abstract_origin" in die.attributes:
+		die = get_die_at_offset(cu, die.attributes["DW_AT_abstract_origin"].value)
+	if "DW_AT_type" in die.attributes:
+		tdie = get_die_at_offset(cu, die.attributes["DW_AT_type"].value)
+		# while tdie.tag == "DW_TAG_typedef":
+		# 	tdie = get_die_at_offset(cu, tdie.attributes["DW_AT_type"].value)
+		if "DW_AT_byte_size" in tdie.attributes:
+			return tdie.attributes["DW_AT_byte_size"].value
+	return -1 # void
 
 def get_parameters_from_die(cu, die):
 	parameters = []


### PR DESCRIPTION
This changes the python import statements to work with python3. Additionally, the `make install-python` will now use `pip3` by default, and install to the python user site packages rather than the system one by default (to avoid needing sudo). An additional rule, `make install-python2` has been added to retain python2 support.